### PR TITLE
Fix issues with pdf subcommand on macos due to directory mount

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,12 @@ $(ARTIFACT_DIR)/pages/index.html: md-slides README.md | $(ARTIFACT_DIR)/pages
 	@./md-slides html README.md $(dir $@)
 	@cp -v windmill.jpeg $(dir $@)
 
+## Generate pages pdf content
 .PHONY: pages
 pages: $(ARTIFACT_DIR)/pages/index.html
 	$(LOG) Pages available at $(dir $<)
+
+## Run more detailed integration tests
+.PHONY: integ-test
+integ-test: md-slides
+	@./md-slides pdf -tmp-dir artifacts README.md artifacts/test.pdf

--- a/cmd/md-slides/main.go
+++ b/cmd/md-slides/main.go
@@ -16,6 +16,7 @@ Subcommands:
   serve     serve the slides as html
   html      render slide html to a directory
   pdf       export the slides to a pdf
+
 `
 
 

--- a/cmd/md-slides/subcommand_pdf.go
+++ b/cmd/md-slides/subcommand_pdf.go
@@ -17,6 +17,10 @@ import (
 
 const pdfUsage = `Render the slides to pdf.
 
+NOTE: if you're running with Docker on macos, you may need to use the 
+-tmp-dir flag to create the temporary directory in a location that is
+mountable into the Docker vm.
+
 Usage:
   md-slides pdf [options...] [file.md] [output.pdf]
 


### PR DESCRIPTION
Added the `-tmp-dir` flag.